### PR TITLE
fix(streamToRx): now returns Observable, cleans up listeners

### DIFF
--- a/src/streamToRx.test.ts
+++ b/src/streamToRx.test.ts
@@ -1,9 +1,7 @@
 import {expect} from 'chai';
 import * as stream from 'stream';
 import { reduce } from 'rxjs/operators';
-import {
-    streamToStringRx
-} from './index';
+import { streamToStringRx } from './index';
 
 describe('Validate Rx From Stream', () => {
     it('tests stream to Rx', () => {
@@ -18,4 +16,9 @@ describe('Validate Rx From Stream', () => {
             });
     });
 
+    it('should not be a subject', () => {
+        const bufferStream = new stream.PassThrough();
+        const observable = streamToStringRx(bufferStream);
+        expect((observable as any).next).not.to.be.a('function');
+    });
 });

--- a/src/streamToRx.ts
+++ b/src/streamToRx.ts
@@ -1,12 +1,22 @@
-import {Subject, Observable} from 'rxjs';
+import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators'
 
-export function streamToRx(stream: NodeJS.ReadableStream): Subject<Buffer> {
-    const subject = new Subject<Buffer>();
-    stream.on('end', () => subject.complete());
-    stream.on('error', (e: Error) => subject.error(e));
-    stream.on('data', (data: Buffer) => subject.next(data));
-    return subject;
+export function streamToRx(stream: NodeJS.ReadableStream): Observable<Buffer> {
+    return new Observable<Buffer>(subscriber => {
+        const endHandler = () => subscriber.complete();
+        const errorHandler = (e: Error) => subscriber.error(e);
+        const dataHandler = (data: Buffer) => subscriber.next(data);
+
+        stream.addListener('end', endHandler);
+        stream.addListener('error', errorHandler);
+        stream.addListener('data', dataHandler);
+
+        return () => {
+            stream.removeListener('end', endHandler);
+            stream.removeListener('error', errorHandler);
+            stream.removeListener('data', dataHandler);
+        };
+    });
 }
 
 export function streamToStringRx(stream: NodeJS.ReadableStream, encoding: string = 'UTF-8'): Observable<string> {


### PR DESCRIPTION
This reimplements streamToRx such that it is just an Observable and not a Subject, that way users cannot call `next` on the result.

This commit also makes sure that event listeners are removed from the underlying stream.

BREAKING CHANGE: No longer returns a Subject

(You'll want to increment a major revision on next publish because this is breaking)