### PR TITLE
feat: unsubscribe from source stream on destroy

### DIFF
--- a/src/rxToStream.ts
+++ b/src/rxToStream.ts
@@ -37,6 +37,12 @@ class ReadableObservableStream<T> extends stream.Readable {
         }
     }
 
+    _destroy() {
+        if (this._subscription) {
+            this._subscription.unsubscribe();
+        }
+    }
+
     _read() {
         const { _buffer } = this;
 


### PR DESCRIPTION
Subscriptions should be teared down by unsubscribing the subscriptions. It is also by convention that streams should be destroyed when we are done reading/writing.

Without these changes, if we do not `destroy` the stream returned by `rxToStream` then converted source observable will never be unsubscribed from. As a result, given that this observable can be an infinite observable (e.g. audio stream from network) - it will continue to be alive even though we are not "listening" anymore.