### PR TITLE
Update to rxjs 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [4.0.0] (https://github.com/Jason3S/rx-stream/compare/v3.3.0...v4.0.0) (2021-12-08)
+
+* Move to RxJs 7
+
 ## [3.3.0](https://github.com/Jason3S/rx-stream/compare/v3.2.1...v3.3.0) (2021-07-18)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rxjs-stream",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4104,12 +4104,20 @@
       }
     },
     "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "~2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rxjs-stream",
-  "version": "3.3.0",
-  "description": "nodejs streams for rxjs 6",
+  "version": "4.0.0",
+  "description": "nodejs streams for rxjs 7",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {
@@ -61,13 +61,13 @@
     "nyc": "^15.0.0",
     "prettier": "^2.4.1",
     "rimraf": "^3.0.2",
-    "rxjs": "^6.6.7",
+    "rxjs": "^7.0.0",
     "ts-node": "^10.2.1",
     "typescript": "^4.4.3"
   },
   "dependencies": {},
   "peerDependencies": {
-    "rxjs": "^6.0.0"
+    "rxjs": "^7.0.0"
   },
   "engines": {
     "node": ">=8.3.0"


### PR DESCRIPTION
Fixes #110.

Simply updating the rxjs version to 7 seems to work fine, all tests pass.

I also took the liberty to add a CHANGELOG entry  and bump the packet version, in the hope that this will ease the release of new version.

Cheers. 