### PR TITLE
feat!: Drop support for Node 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 12.x
           - 14.x
           - 16.x
           - 18.x

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "rxjs": "^7.0.0"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "files": [
     "dist",


### PR DESCRIPTION
BREAKING CHANGE: Drop support for Node 12

Note: The code has not changed, but the cost of maintaining the tools is too high.